### PR TITLE
Fix lemonsqueezy product validation

### DIFF
--- a/SpareBrainedLicensing_APP/CLAUDE.md
+++ b/SpareBrainedLicensing_APP/CLAUDE.md
@@ -1,0 +1,132 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is **Spare Brained Licensing** - a Microsoft Dynamics 365 Business Central AL extension that provides a licensing validation and management framework for other BC extensions. It's a defensive security tool that helps extension publishers verify subscription licenses and manage activation/deactivation workflows.
+
+### Key Architecture Components
+
+- **Namespace**: `SPB` (Spare Brained) with sub-namespaces like `SPB.Extensibility`, `SPB.Storage`, `SPB.Callables`
+- **AppSourceCop prefix**: `SPB` (configured in AppSourceCop.json and AL-Go settings)
+- **Central license storage**: `SPBLIC Extension License` table stores all license information
+- **Interface-based platform communication**: Extensible enum pattern with `ILicenseCommunicator` interfaces
+- **Built-in platform support**: Gumroad and LemonSqueezy licensing platforms
+
+## Directory Structure
+
+```
+src/
+├── Callables/           # Public APIs for 3rd party extensions
+├── EngineLogic/         # Core business logic (internal methods)
+├── Extensibility/       # Interfaces and events system
+├── InstallUpgradeBC/    # Installation and upgrade handling
+├── PlatformObjects/     # Platform-specific implementations (Gumroad, LemonSqueezy)
+├── Storage/             # Data persistence layer
+├── Telemetry/           # Application insights integration
+└── UserInterface/       # Pages for license management
+```
+
+## Development Commands
+
+Since this is an AL project using AL-Go framework:
+
+- **Build**: Handled by AL-Go CI/CD pipeline (no local build commands)
+- **Testing**: Test project exists in `../SpareBrainedLicensing_TEST/` 
+- **Code Analysis**: Uses AL-Go with CodeCop, UICop, PerTenantExtensionCop, AppSourceCop
+- **Ruleset**: Custom rules in `src/.rulesets/SPBLicensing.ruleset.json`
+
+## Core Architectural Patterns
+
+### Interface-Based Platform Integration
+The system uses extensible enums implementing multiple interfaces:
+- `ILicenseCommunicator`: Basic license verification and misuse reporting
+- `ILicenseCommunicator2`: Activation/deactivation operations and test data
+- `IUsageIntegration`: Usage-based billing support
+
+### Public API Layer
+Extensions integrate via `SPB.Callables` namespace:
+- `SPBLIC Extension Registration`: Register extensions for licensing
+- `SPBLIC Check Active`: Verify if licenses are active (with/without submodules)
+- `SPBLIC Log Usage`: Report usage for usage-based billing
+
+### License State Management
+Core workflow through `SPB.EngineLogic`:
+- `CheckActiveMeth`: Determines if license is currently valid
+- `ActivateMeth`: Handles license key activation process
+- `DeactivateMeth`: Manages deactivation (local and platform)
+- `LogUsageMeth`: Reports usage metrics to platforms
+
+### Data Architecture
+- **Primary table**: `SPBLIC Extension License` (cross-company, AccountData classification)
+- **Key fields**: Entry Id (GUID), Extension App Id, Submodule Name, License Platform
+- **Isolated storage**: `IsoStoreManager` for sensitive data persistence
+- **Trial support**: Grace periods with environment-specific rules
+
+## Extension Points
+
+### Events System
+`SPBLIC Events` codeunit provides integration points:
+- `OnAfterCheckActiveBasic`: After license validation
+- `OnAfterCheckActiveBasicFailure`: When license check fails
+- `OnBeforeLaunchProductUrl`: Before opening product pages
+
+### Platform Extension
+Add new licensing platforms by:
+1. Extending `SPBLIC License Platform` enum
+2. Implementing the three core interfaces
+3. Adding platform-specific codeunit in `PlatformObjects/`
+
+### API Key Management
+Extensible API key providers via `SPBLIC ApiKeyProvider` enum and `IApiKeyProvider` interface.
+
+## Security and Compliance
+
+- **Data classification**: Proper CustomerContent/SystemMetadata/AccountData classification
+- **Permissions**: Uses InherentPermissions throughout
+- **Sensitive data**: License keys use ExtendedDatatype = Masked
+- **Cross-company**: License table spans all companies (DataPerCompany = false)
+- **Telemetry**: Application Insights integration for monitoring
+
+## Development Guidelines
+
+- **Error handling**: Use Label declarations, avoid technical jargon in user messages
+- **XML documentation**: All public procedures have comprehensive documentation
+- **Testing**: Comprehensive test coverage in separate test app
+- **Versioning**: Follows semantic versioning, maintains backward compatibility
+- **Environment handling**: Different grace periods for Production vs Sandbox
+- **Submodule support**: Optional feature for licensing parts of extensions
+
+## Integration Examples
+
+### Basic License Check
+```al
+procedure CheckMyExtensionLicense()
+var
+    CheckActive: Codeunit "SPBLIC Check Active";
+begin
+    // Simple check with error dialog if inactive
+    CheckActive.CheckBasic(MyAppId, true);
+end;
+```
+
+### Extension Registration
+```al
+procedure RegisterMyExtension()
+var
+    ExtensionRegistration: Codeunit "SPBLIC Extension Registration";
+    AppInfo: ModuleInfo;
+    LicensePlatform: Enum "SPBLIC License Platform";
+begin
+    NavApp.GetCurrentModuleInfo(AppInfo);
+    LicensePlatform := LicensePlatform::Gumroad;
+    
+    ExtensionRegistration.RegisterExtension(
+        AppInfo, ProductCode, ProductUrl, SupportUrl, 
+        BillingEmail, VersionUrl, UpdateNewsUrl,
+        7, 30, Version.Create('25.0.0.0'), LicensePlatform, false);
+end;
+```
+
+This framework enables extension publishers to easily add subscription-based licensing to their BC extensions while providing a unified management experience for end users.

--- a/SpareBrainedLicensing_APP/src/EngineLogic/ActivateMeth.Codeunit.al
+++ b/SpareBrainedLicensing_APP/src/EngineLogic/ActivateMeth.Codeunit.al
@@ -1,6 +1,7 @@
 namespace SPB.EngineLogic;
 
 using SPB.Extensibility;
+using SPB.PlatformObjects.LemonSqueezy;
 using SPB.Storage;
 using SPB.Telemetry;
 
@@ -90,19 +91,18 @@ codeunit 71033587 "SPBLIC Activate Meth"
     local procedure ValidateBeforeActivation(var SPBExtensionLicense: Record "SPBLIC Extension License")
     var
         LemonSqueezyComm: Codeunit "SPBLIC LemonSqueezy Comm.";
-        ResponseBody: Text;
         PreValidationFailedErr: Label 'Unable to validate license key before activation. Please check your internet connection and try again.';
         AppInfo: ModuleInfo;
+        ResponseBody: Text;
     begin
         // For LemonSqueezy platform, validate the license key first to prevent consuming it for wrong products
-        if SPBExtensionLicense."License Platform" = SPBExtensionLicense."License Platform"::LemonSqueezy then begin
+        if SPBExtensionLicense."License Platform" = SPBExtensionLicense."License Platform"::LemonSqueezy then
             if LemonSqueezyComm.CallAPIForPreActivationValidation(SPBExtensionLicense, ResponseBody) then
                 LemonSqueezyComm.ValidateProductMatch(SPBExtensionLicense, ResponseBody)
             else begin
                 NavApp.GetModuleInfo(SPBExtensionLicense."Extension App Id", AppInfo);
                 Error(PreValidationFailedErr);
             end;
-        end;
         // Other platforms can add their own pre-validation logic here
     end;
 

--- a/SpareBrainedLicensing_APP/src/EngineLogic/ActivateMeth.Codeunit.al
+++ b/SpareBrainedLicensing_APP/src/EngineLogic/ActivateMeth.Codeunit.al
@@ -91,11 +91,17 @@ codeunit 71033587 "SPBLIC Activate Meth"
     var
         LemonSqueezyComm: Codeunit "SPBLIC LemonSqueezy Comm.";
         ResponseBody: Text;
+        PreValidationFailedErr: Label 'Unable to validate license key before activation. Please check your internet connection and try again.';
+        AppInfo: ModuleInfo;
     begin
         // For LemonSqueezy platform, validate the license key first to prevent consuming it for wrong products
         if SPBExtensionLicense."License Platform" = SPBExtensionLicense."License Platform"::LemonSqueezy then begin
             if LemonSqueezyComm.CallAPIForPreActivationValidation(SPBExtensionLicense, ResponseBody) then
-                LemonSqueezyComm.ValidateProductMatch(SPBExtensionLicense, ResponseBody);
+                LemonSqueezyComm.ValidateProductMatch(SPBExtensionLicense, ResponseBody)
+            else begin
+                NavApp.GetModuleInfo(SPBExtensionLicense."Extension App Id", AppInfo);
+                Error(PreValidationFailedErr);
+            end;
         end;
         // Other platforms can add their own pre-validation logic here
     end;

--- a/SpareBrainedLicensing_APP/src/PlatformObjects/LemonSqueezy/LemonSqueezyComm.Codeunit.al
+++ b/SpareBrainedLicensing_APP/src/PlatformObjects/LemonSqueezy/LemonSqueezyComm.Codeunit.al
@@ -418,7 +418,7 @@ codeunit 71033582 "SPBLIC LemonSqueezy Comm." implements "SPBLIC ILicenseCommuni
 
         // Get the meta object which contains product validation information
         if not JObject.Get('meta', Meta) then
-            exit; // No meta object, skip validation for now
+            Error(MissingMetaErr);
 
         // Extract product_id from meta object
         if Meta.AsObject().Get('product_id', ProductIdToken) then begin

--- a/SpareBrainedLicensing_APP/src/PlatformObjects/LemonSqueezy/LemonSqueezyComm.Codeunit.al
+++ b/SpareBrainedLicensing_APP/src/PlatformObjects/LemonSqueezy/LemonSqueezyComm.Codeunit.al
@@ -60,6 +60,16 @@ codeunit 71033582 "SPBLIC LemonSqueezy Comm." implements "SPBLIC ILicenseCommuni
         exit(CallLemonSqueezy(ResponseBody, VerifyAPI, SPBExtensionLicense.ApiKeyProvider));
     end;
 
+    internal procedure CallAPIForPreActivationValidation(var SPBExtensionLicense: Record "SPBLIC Extension License"; var ResponseBody: Text): Boolean
+    var
+        LemonSqueezyValidateOnlyAPITok: Label 'https://api.lemonsqueezy.com/v1/licenses/validate?license_key=%1', Comment = '%1 is the license key', Locked = true;
+        ValidateAPI: Text;
+    begin
+        // Validate license key without instance_id parameter for pre-activation validation
+        ValidateAPI := StrSubstNo(LemonSqueezyValidateOnlyAPITok, SPBExtensionLicense."License Key");
+        exit(this.CallLemonSqueezy(ResponseBody, ValidateAPI, SPBExtensionLicense.ApiKeyProvider));
+    end;
+
     procedure CallAPIForDeactivation(var SPBExtensionLicense: Record "SPBLIC Extension License"; var ResponseBody: Text) ResultOK: Boolean
     var
         DeactivateAPI: Text;
@@ -205,6 +215,9 @@ codeunit 71033582 "SPBLIC LemonSqueezy Comm." implements "SPBLIC ILicenseCommuni
         end;
         if SqueezyResponseType = SqueezyResponseType::" " then
             Error(CommunicationFailureErr, AppInfo.Publisher());
+
+        // Validate that the license key belongs to the correct product
+        this.ValidateProductMatch(SPBExtensionLicense, ResponseBody);
 
         TempJsonBuffer.ReadFromText(ResponseBody);
 
@@ -390,5 +403,32 @@ codeunit 71033582 "SPBLIC LemonSqueezy Comm." implements "SPBLIC ILicenseCommuni
         Relationships.Add('subscription-item', SubscriptionItem);
         Data.Add('relationships', Relationships);
         Result.Add('data', Data);
+    end;
+
+    internal procedure ValidateProductMatch(var SPBExtensionLicense: Record "SPBLIC Extension License"; ResponseBody: Text)
+    var
+        JObject: JsonObject;
+        Meta, ProductIdToken: JsonToken;
+        ProductIdFromAPI: Text;
+        ProductMismatchErr: Label 'License key does not belong to the expected product. Expected product code %1, but license is for a different product.', Comment = '%1 is the expected Product Code';
+    begin
+        // Parse the response to extract product information from meta object
+        if not JObject.ReadFrom(ResponseBody) then
+            exit; // Invalid JSON, let other validation handle this
+
+        // Get the meta object which contains product validation information
+        if not JObject.Get('meta', Meta) then
+            exit; // No meta object, skip validation for now
+
+        // Extract product_id from meta object
+        if Meta.AsObject().Get('product_id', ProductIdToken) then begin
+            ProductIdFromAPI := ProductIdToken.AsValue().AsText();
+            
+            // Compare with the registered Product Code
+            // LemonSqueezy product_id should match the Product Code registered for this extension
+            if (SPBExtensionLicense."Product Code" <> '') and 
+               (SPBExtensionLicense."Product Code" <> ProductIdFromAPI) then
+                Error(ProductMismatchErr, SPBExtensionLicense."Product Code");
+        end;
     end;
 }


### PR DESCRIPTION
## Summary

  This PR fixes a critical security vulnerability in the LemonSqueezy license validation system where license keys could be
  activated for the wrong products, potentially consuming valid license keys inappropriately.

  ## Problem

  The current LemonSqueezy implementation did not validate that a license key actually belongs to the expected product before
   activation. According to the [LemonSqueezy API 
  documentation](https://docs.lemonsqueezy.com/api/license-api/activate-license-key), both activate and validate endpoints
  return a `meta` object containing `product_id` that should be validated against the registered product.

  **Risk**: A license key for Product A could be used to activate Product B, consuming the license key even though it belongs
   to the wrong product.

  ## Solution

  ### 1. Pre-Activation Validation
  - Added `CallAPIForPreActivationValidation()` method that calls LemonSqueezy's validate API **without** `instance_id`
  parameter
  - This validates the license key without consuming/activating it
  - Called **before** the activation API to prevent consuming wrong license keys

  ### 2. Product Validation
  - Enhanced `ValidateProductMatch()` method that extracts `product_id` from API response's `meta` object
  - Compares against the registered `Product Code` in the license table
  - Throws clear error if license belongs to different product: *"License key does not belong to the expected product"*

  ### 3. Updated Activation Flow
  1. Pre-validate license key (doesn't consume)
  2. Check product match
  3. If valid → proceed with activation
  4. If invalid → throw error without consuming license

  ## Files Changed

  - `src/PlatformObjects/LemonSqueezy/LemonSqueezyComm.Codeunit.al`
    - Added `CallAPIForPreActivationValidation()` method
    - Enhanced `ValidateProductMatch()` with product validation logic
    - Added validation call in `PopulateSubscriptionFromResponse()`

  - `src/EngineLogic/ActivateMeth.Codeunit.al`
    - Added `ValidateBeforeActivation()` method
    - Integrated pre-validation into activation flow

  ## Test Plan

  - [ ] Test activation with correct product license key
  - [ ] Test activation with license key for different product (should fail with clear error)
  - [ ] Test activation with invalid license key
  - [ ] Verify license key is not consumed when validation fails
  - [ ] Test existing license verification still works

  ## Security Impact

  ✅ **Prevents license key misuse** - License keys can only be activated for their intended products
  ✅ **Prevents license consumption** - Invalid attempts don't consume valid license keys
  ✅ **Clear error messages** - Users get actionable feedback when using wrong license keys

  🤖 Generated with [Claude Code](https://claude.ai/code)