### PR TITLE
Fix Lemon Squeezy to deactivate on platform. #39

### DIFF
--- a/SpareBrainedLicensing_APP/src/EngineLogic/DeactivateMeth.Codeunit.al
+++ b/SpareBrainedLicensing_APP/src/EngineLogic/DeactivateMeth.Codeunit.al
@@ -27,12 +27,6 @@ codeunit 71033588 "SPBLIC Deactivate Meth"
     begin
         NavApp.GetModuleInfo(SPBExtensionLicense."Extension App Id", AppInfo);
 
-        SPBExtensionLicense.Validate(Activated, false);
-        ClearSubscriptionMetadata(SPBExtensionLicense);
-        SPBExtensionLicense.Modify();
-        SPBLICIsoStoreManager.UpdateOrCreateIsoStorage(SPBExtensionLicense);
-        Commit();  // if calling the API fails, the local should still be marked as deactivated
-
         if ByPlatform then begin
             LicensePlatformV2 := SPBExtensionLicense."License Platform";
             if not LicensePlatformV2.CallAPIForDeactivation(SPBExtensionLicense, ResponseBody) then begin
@@ -46,6 +40,12 @@ codeunit 71033588 "SPBLIC Deactivate Meth"
             SPBLICTelemetry.LicenseDeactivation(SPBExtensionLicense);
             SPBLICEvents.OnAfterLicenseDeactivated(SPBExtensionLicense);
         end;
+
+        SPBExtensionLicense.Validate(Activated, false);
+        ClearSubscriptionMetadata(SPBExtensionLicense);
+        SPBExtensionLicense.Modify();
+        SPBLICIsoStoreManager.UpdateOrCreateIsoStorage(SPBExtensionLicense);
+
     end;
 
     local procedure ClearSubscriptionMetadata(var SPBExtensionLicense: Record "SPBLIC Extension License")

--- a/SpareBrainedLicensing_APP/src/EngineLogic/DeactivateMeth.Codeunit.al
+++ b/SpareBrainedLicensing_APP/src/EngineLogic/DeactivateMeth.Codeunit.al
@@ -37,6 +37,7 @@ codeunit 71033588 "SPBLIC Deactivate Meth"
             SPBLICTelemetry.LicensePlatformDeactivation(SPBExtensionLicense);
             SPBLICEvents.OnAfterLicenseDeactivatedByPlatform(SPBExtensionLicense, ResponseBody);
         end else begin
+            DeactivationSuccess := true;
             SPBLICTelemetry.LicenseDeactivation(SPBExtensionLicense);
             SPBLICEvents.OnAfterLicenseDeactivated(SPBExtensionLicense);
         end;
@@ -45,7 +46,6 @@ codeunit 71033588 "SPBLIC Deactivate Meth"
         ClearSubscriptionMetadata(SPBExtensionLicense);
         SPBExtensionLicense.Modify();
         SPBLICIsoStoreManager.UpdateOrCreateIsoStorage(SPBExtensionLicense);
-
     end;
 
     local procedure ClearSubscriptionMetadata(var SPBExtensionLicense: Record "SPBLIC Extension License")

--- a/SpareBrainedLicensing_APP/src/UserInterface/ExtensionLicenses.Page.al
+++ b/SpareBrainedLicensing_APP/src/UserInterface/ExtensionLicenses.Page.al
@@ -192,19 +192,21 @@ page 71033575 "SPBLIC Extension Licenses"
     var
         SPBLICDeactivateMeth: Codeunit "SPBLIC Deactivate Meth";
         DoDeactivation: Boolean;
+        DeactivateOnPlatform: Boolean;
         LicensePlatform: Interface "SPBLIC ILicenseCommunicator2";
-        DeactivationNotPossibleWarningQst: Label 'This will deactivate this license in this Business Central instance, but you will need to contact the Publisher to release the assigned license. \ \Are you sure you want to deactivate this license?';
-        DeactivationPossibleQst: Label 'This will deactivate this license in this Business Central instance.\ \Are you sure you want to deactivate this license?';
+        PlatformDeactivationNotPossibleWarningQst: Label 'This will deactivate this license in this Business Central instance, but you will need to contact the Publisher to release the assigned license. \ \Are you sure you want to deactivate this license?';
+        PlatformDeactivationPossibleQst: Label 'This will deactivate this license in this Business Central instance.\ \Are you sure you want to deactivate this license?';
     begin
         LicensePlatform := SPBExtensionLicense."License Platform";
 
         // Depending on the platform capabilities, we give the user a different message
-        if LicensePlatform.ClientSideDeactivationPossible(SPBExtensionLicense) then
-            DoDeactivation := Confirm(DeactivationPossibleQst, false)
+        DeactivateOnPlatform := LicensePlatform.ClientSideDeactivationPossible(SPBExtensionLicense);
+        if DeactivateOnPlatform then
+            DoDeactivation := Confirm(PlatformDeactivationPossibleQst, false)
         else
-            DoDeactivation := Confirm(DeactivationNotPossibleWarningQst, false);
+            DoDeactivation := Confirm(PlatformDeactivationNotPossibleWarningQst, false);
 
         if DoDeactivation then
-            exit(SPBLICDeactivateMeth.Deactivate(SPBExtensionLicense, false));
+            exit(SPBLICDeactivateMeth.Deactivate(SPBExtensionLicense, DeactivateOnPlatform));
     end;
 }


### PR DESCRIPTION
To fix issue #39 
- Changed `DeactivateMeth.Codeunit.al` `DoDeactivate()` to set the record as deactivated if the API request does not fail.
- Changed `LemonSqueezyComm.Codeunit.al` to handle 404 response in the case the deactivate API does not find the license.
